### PR TITLE
fixes-hotreload-issue

### DIFF
--- a/StartupServicesExtensions.cs
+++ b/StartupServicesExtensions.cs
@@ -55,8 +55,8 @@ namespace web
                         //options.Conventions.AddFolderApplicationModelConvention("/Production", model => model.Filters.Add(new OnlyProducersPageFilter(onlyProducersLogger, roleService, cookieManager)));
                     });
 
-            services.AddControllersWithViews().AddRazorRuntimeCompilation();
-            services.AddRazorPages().AddRazorRuntimeCompilation();
+            services.AddControllersWithViews();
+            services.AddRazorPages();
 
             services.AddHttpContextAccessor();
 

--- a/web.csproj
+++ b/web.csproj
@@ -6,8 +6,5 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="6.0.0" />
-  </ItemGroup>
 
 </Project>


### PR DESCRIPTION
remove nuget reference to Razor RuntimeCompilation
remove services.Add*().AddRazorRuntimeCompilation() calls

these two combined allows dotnet watch to do its thing.

fixes #1 
